### PR TITLE
Use path.join for macOS compat

### DIFF
--- a/pkg_rename.py
+++ b/pkg_rename.py
@@ -103,7 +103,7 @@ def renamePkg(pkg_file_path):
 				if (os.path.split(pkg_file_path)[1] == format_out):
 					print '  Skipped, same filename already set.'
 				else:
-					pkg_new_file_path = os.path.dirname(os.path.abspath(pkg_file_path)) + '\\' + format_out
+					pkg_new_file_path = os.path.join(os.path.dirname(os.path.abspath(pkg_file_path)), format_out)
 					if os.path.exists(pkg_new_file_path):
 						raise pkg_parser.MyError('file \''+pkg_new_file_path+'\' already exists!')
 					else:


### PR DESCRIPTION
Fixes #5

Using \ literal causes the rename to operate incorrectly.

`$ python pkg_rename.py ~/Desktop/foo.pkg`

Renames _and_ moves the file to:

`~/Desktop\{the-formatted-name}.pkg`

Thanks!